### PR TITLE
Enhance dark theme

### DIFF
--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -53,13 +53,13 @@ const { url, title, img, description, pubDate } = Astro.props;
   li a p {
     font-size: 2vh;
     text-align: center;
-    background-color: #9d00ff;
+    background-color: var(--accent-color);
     border-radius: 5px 5px 0 0;
     margin: 0;
   }
 
   li:hover {
-    border-color: #8400d6;
+    border-color: var(--accent-hover-color);
   }
 
   .image-container {

--- a/src/components/Social.astro
+++ b/src/components/Social.astro
@@ -13,7 +13,7 @@ const { platform, username } = Astro.props;
   }
 
   a:hover {
-    background-color: #d8664b;
+    background-color: var(--accent-hover-color);
   }
 </style>
 

--- a/src/components/ThemeIcon.astro
+++ b/src/components/ThemeIcon.astro
@@ -23,17 +23,17 @@
     cursor: pointer;
   }
   .sun {
-    fill: black;
+    fill: transparent;
   }
   .moon {
-    fill: transparent;
+    fill: white;
   }
 
-  :global(.dark) .sun {
-    fill: transparent;
+  :global(.light) .sun {
+    fill: black;
   }
-  :global(.dark) .moon {
-    fill: white;
+  :global(.light) .moon {
+    fill: transparent;
   }
 
   #themeToggle svg {
@@ -49,7 +49,7 @@
     localStorage.getItem('theme') ||
     (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 
-  document.documentElement.classList.toggle('dark', theme === 'dark');
+  document.documentElement.classList.toggle('light', theme === 'light');
   localStorage.setItem('theme', theme);
 
   const handleToggleClick = () => {
@@ -59,13 +59,9 @@
       setTimeout(() => button.classList.remove('rotate'), 500);
     }
 
-    const isDark = document.documentElement.classList.toggle('dark');
+    const isLight = document.documentElement.classList.toggle('light');
 
-    document
-      .querySelectorAll('.carousel-box, .blog-nav-container')
-      .forEach((el) => el.classList.toggle('dark', isDark));
-
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    localStorage.setItem('theme', isLight ? 'light' : 'dark');
   };
 
   document

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -18,9 +18,9 @@ const { pageTitle } = Astro.props;
       (function () {
         const stored = localStorage.getItem('theme');
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (stored === 'dark' || (!stored && prefersDark)) {
-          document.documentElement.classList.add('dark');
-          localStorage.setItem('theme', 'dark');
+        if (stored === 'light' || (!stored && !prefersDark)) {
+          document.documentElement.classList.add('light');
+          localStorage.setItem('theme', 'light');
         }
       })();
     </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,9 +1,13 @@
 :root {
-  --font-family: Arial, sans-serif;
-  --background-color: #f1f5f7;
-  --text-color: #000;
-  --accent-color: #ff9776;
-  --nav-background: var(--accent-color);
+  --font-family: 'Segoe UI', Tahoma, sans-serif;
+  --background-color: #121212;
+  --text-color: #e0e0e0;
+  --accent-color: #2196f3;
+  --accent-hover-color: #1976d2;
+  --nav-background: rgba(255, 255, 255, 0.1);
+  --glass-blur: blur(10px);
+  --glass-bg: rgba(255, 255, 255, 0.05);
+  --glass-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
 }
 
 html {
@@ -14,14 +18,11 @@ html {
   transition: background-color 0.3s ease, color 0.3s ease;
 }
 
-html.dark {
-  --background-color: #333;
-  --text-color: #fff;
-  --nav-background: #444;
-}
+html.light {
+  --background-color: #f1f5f7;
+  --text-color: #000;
+  --nav-background: rgba(255, 255, 255, 0.6);
 
-.dark .nav-links a {
-  color: var(--text-color);
 }
 
 body {
@@ -55,14 +56,12 @@ h1 {
 
 .blog-nav-container {
   text-align: center;
-  background-color: var(--accent-color);
+  background-color: var(--glass-bg);
+  backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-shadow);
   border-radius: 5px;
   overflow: hidden;
   animation: fadeIn 0.8s ease-in-out;
-}
-
-.dark .blog-nav-container {
-  background-color: #222;
 }
 
 /* nav styles */
@@ -78,6 +77,7 @@ h1 {
   height: 5px;
   margin-bottom: 10px;
   background-color: var(--accent-color);
+  border-radius: 2px;
 }
 
 .nav-links {
@@ -85,6 +85,9 @@ h1 {
   top: 5rem;
   left: 48px;
   background-color: var(--nav-background);
+  backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-shadow);
+  border-radius: 5px;
   margin: 0;
   overflow: hidden;
   max-height: 0;
@@ -96,6 +99,7 @@ h1 {
   text-align: center;
   padding: 10px 0;
   text-decoration: none;
+  color: var(--text-color);
   font-size: 1.2rem;
   font-weight: bold;
   text-transform: uppercase;
@@ -103,7 +107,7 @@ h1 {
 
 .nav-links a:hover,
 .nav-links a:focus {
-  background-color: var(--accent-color);
+  background-color: var(--accent-hover-color);
 }
 
 .expanded {
@@ -116,7 +120,9 @@ h1 {
     display: block;
     position: static;
     width: auto;
-    background: none;
+    background: transparent;
+    backdrop-filter: none;
+    box-shadow: none;
     max-height: none;
   }
 
@@ -156,7 +162,7 @@ h1 {
   position: absolute;
   top: 90%;
   padding: 10px 20px;
-  background-color: #717171;
+  background-color: var(--accent-color);
   color: #fff;
   border: none;
 
@@ -167,7 +173,7 @@ h1 {
 
 .carousel-next:hover,
 .carousel-previous:hover {
-  background-color: #555;
+  background-color: var(--accent-hover-color);
   transform: scale(1.3);
 }
 
@@ -175,12 +181,10 @@ h1 {
   flex: 1 0 100%;
   display: flex;
   align-items: flex-start;
-  background-color: #d5d5d5;
+  background-color: var(--glass-bg);
+  backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-shadow);
   transition: background-color 0.3s ease;
-}
-
-.dark .carousel-box {
-  background-color: #444;
 }
 
 @media screen and (min-width: 636px) {


### PR DESCRIPTION
## Summary
- set dark theme variables as default and add light override
- apply modern glassy design
- switch theme scripts to use `light` class

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843926667688320872b57e08357fea9